### PR TITLE
Ensured physics works when passed in

### DIFF
--- a/demo/size.html
+++ b/demo/size.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta http-equiv="X-UA-Compatible" content="ie=edge">
+    <title>Document</title>
+</head>
+<body>
+    <script async src="../lib/size.js"></script>
+</body>
+</html>

--- a/src/emojisplosion.ts
+++ b/src/emojisplosion.ts
@@ -38,7 +38,7 @@ export interface IEmojisplosionSettings {
     /**
      * Runtime change constants for emoji element movements.
      */
-    physics: IEmojiPhysics;
+    physics: Partial<IEmojiPhysics>;
 
     /**
      * How to determine where to place blasts of emojis around the page.
@@ -150,15 +150,16 @@ export const emojisplosion = (settings: Partial<IEmojisplosionSettings> = {}) =>
         uniqueness = Infinity,
     } = settings;
 
+    createStyleElementAndClass(className);
+
     const physics = {
         ...defaultPhysics,
+        ...settings.physics,
         initialVelocities: {
             ...defaultPhysics.initialVelocities,
             ...(settings.physics !== undefined ? settings.physics.initialVelocities : {}),
         },
     };
-
-    createStyleElementAndClass(className);
 
     const emojiSettings = {
         className,

--- a/src/mains/size.ts
+++ b/src/mains/size.ts
@@ -1,0 +1,12 @@
+import { emojisplosions } from "../emojisplosions";
+
+emojisplosions({
+    emojiCount: () => Math.random() * 20 + 20,
+    emojis: ["💖", "💕", "💗", "💓", "💝"],
+    physics: {
+        fontSize: {
+            max: 54,
+            min: 24,
+        },
+    },
+});

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -5,6 +5,7 @@ module.exports = {
         easy: "./src/mains/easy.ts",
         global: "./src/mains/global.ts",
         onclick: "./src/mains/onclick.ts",
+        size: "./src/mains/size.ts",
     },
     mode: "production",
     module: {


### PR DESCRIPTION
Turns out `settings.physics` wasn't being used in the object passed to `EmojiActor`. Whoops! Also typed it to be `Partial<IEmojiPhysics>` so folks don't have to pass the full thing in.

Added a size demo.

Fixes #8.