### PR TITLE
Only blast emojis if the document is visible

### DIFF
--- a/src/emojisplosions.ts
+++ b/src/emojisplosions.ts
@@ -67,7 +67,10 @@ export const emojisplosions = (settings: Partial<EmojisplosionsSettings> = {}): 
             return;
         }
 
-        blast();
+        if (document.visibilityState === "visible") {
+            blast();
+        }
+
         scheduler(blastAndSchedule, obtainValue(interval));
     };
 
@@ -75,7 +78,7 @@ export const emojisplosions = (settings: Partial<EmojisplosionsSettings> = {}): 
 
     return {
         blast,
-        cancel(): void {
+        cancel() {
             cancelled = true;
         },
     };


### PR DESCRIPTION
I'm seeing that if I leave a tab open in the background for a while, emojisplosion will have a whole _bunch_ of emojis fire. Which tanks the page. Not great.

