### PR TITLE
fix: ensure window width and height are defined

### DIFF
--- a/src/actor.ts
+++ b/src/actor.ts
@@ -235,8 +235,8 @@ export class EmojiActor {
         this.position.x += this.velocity.x * timeElapsed / this.physics.framerate;
         this.position.y += this.velocity.y * timeElapsed / this.physics.framerate;
 
-        const windowHeight = window.outerHeight ? window.outerHeight : document.documentElement.clientHeight;
-        const windowWidth = window.outerWidth ? window.outerWidth : document.documentElement.clientWidth;
+        const windowHeight = window.outerHeight || document.documentElement.clientHeight;
+        const windowWidth = window.outerWidth || document.documentElement.clientWidth;
 
         if (!this.physics.preserveOutOfBounds) {
             if (

--- a/src/actor.ts
+++ b/src/actor.ts
@@ -235,17 +235,26 @@ export class EmojiActor {
         this.position.x += this.velocity.x * timeElapsed / this.physics.framerate;
         this.position.y += this.velocity.y * timeElapsed / this.physics.framerate;
 
+        const windowHeight = window.outerHeight ?? document.documentElement.clientHeight;
+        const windowWidth = window.outerWidth ?? document.documentElement.clientWidth;
+
         if (!this.physics.preserveOutOfBounds) {
-            if (this.position.y - this.element.clientHeight > window.outerHeight + outOfBounds) {
-                return true;
+            if (
+              this.position.y - this.element.clientHeight >
+              windowHeight + outOfBounds
+            ) {
+              return true;
             }
 
             if (this.position.y + this.element.clientHeight < -outOfBounds) {
                 return true;
             }
 
-            if (this.position.x - this.element.clientWidth > window.outerWidth + outOfBounds) {
-                return true;
+            if (
+              this.position.x - this.element.clientWidth >
+              windowWidth + outOfBounds
+            ) {
+              return true;
             }
 
             if (this.position.x + this.element.clientWidth < -outOfBounds) {

--- a/src/actor.ts
+++ b/src/actor.ts
@@ -235,8 +235,8 @@ export class EmojiActor {
         this.position.x += this.velocity.x * timeElapsed / this.physics.framerate;
         this.position.y += this.velocity.y * timeElapsed / this.physics.framerate;
 
-        const windowHeight = window.outerHeight ?? document.documentElement.clientHeight;
-        const windowWidth = window.outerWidth ?? document.documentElement.clientWidth;
+        const windowHeight = window.outerHeight ? window.outerHeight : document.documentElement.clientHeight;
+        const windowWidth = window.outerWidth ? window.outerWidth : document.documentElement.clientWidth;
 
         if (!this.physics.preserveOutOfBounds) {
             if (


### PR DESCRIPTION
My client was returning NaN for `window.outerHeight` and `window.outerWidth`, making the actor remove itself prematurely. 

**This change proposes falling back to `document.documentElement.clientHeight` and `document.documentElement.clientWidth` (as those returned correct values)**